### PR TITLE
List card component (reusable) / OT105-60

### DIFF
--- a/src/Components/CommonComponents/ListCardComponent.js
+++ b/src/Components/CommonComponents/ListCardComponent.js
@@ -1,19 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
-import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { Box, Container } from '@mui/material';
 
-const ListCardComponent = () => {
-  const [listData, setListData] = useState();
-
-  useEffect(() => {
-    //method for fetch data and update state
-    //setListData(data);
-  }, []);
+const ListCardComponent = ({ list }) => {
+  const [listData, setListData] = useState(list);
 
   const placeholderImage =
     'https://www.palomacornejo.com/wp-content/uploads/2021/08/no-image.jpg';
@@ -36,25 +29,22 @@ const ListCardComponent = () => {
           margin: '0 auto',
         }}>
         {listData &&
-          listData.map((newData) => (
-            <Card key={newData.id} sx={{ minWidth: 300, maxWidth: 300 }}>
+          listData.map((item) => (
+            <Card key={item.id} sx={{ minWidth: 300, maxWidth: 300 }}>
               <CardMedia
-                alt={newData.title + ' image'}
+                alt={item.title + ' image'}
                 component="img"
                 height="140"
-                image={newData.image || placeholderImage}
+                image={item.image || placeholderImage}
               />
               <CardContent>
                 <Typography gutterBottom component="div" variant="h5">
-                  {newData.title}
+                  {item.title}
                 </Typography>
                 <Typography color="text.secondary" variant="body2">
-                  {newData.description}
+                  {item.description}
                 </Typography>
               </CardContent>
-              <CardActions>
-                <Button size="small">Saber más</Button>
-              </CardActions>
             </Card>
           ))}
       </Container>

--- a/src/Components/CommonComponents/ListCardComponent.js
+++ b/src/Components/CommonComponents/ListCardComponent.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import CardMedia from '@mui/material/CardMedia';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { Box, Container } from '@mui/material';
+
+const ListCardComponent = () => {
+  const [listData, setListData] = useState();
+
+  useEffect(() => {
+    //method for fetch data and update state
+    //setListData(data);
+  }, []);
+
+  const placeholderImage =
+    'https://www.palomacornejo.com/wp-content/uploads/2021/08/no-image.jpg';
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginTop: '20px',
+      }}>
+      <Container
+        sx={{
+          display: 'flex',
+          flexGrow: 1,
+          gap: '20px',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          alignItems: 'start',
+          margin: '0 auto',
+        }}>
+        {listData &&
+          listData.map((newData) => (
+            <Card key={newData.id} sx={{ minWidth: 300, maxWidth: 300 }}>
+              <CardMedia
+                alt={newData.title + ' image'}
+                component="img"
+                height="140"
+                image={newData.image || placeholderImage}
+              />
+              <CardContent>
+                <Typography gutterBottom component="div" variant="h5">
+                  {newData.title}
+                </Typography>
+                <Typography color="text.secondary" variant="body2">
+                  {newData.description}
+                </Typography>
+              </CardContent>
+              <CardActions>
+                <Button size="small">Saber más</Button>
+              </CardActions>
+            </Card>
+          ))}
+      </Container>
+    </Box>
+  );
+};
+
+export default ListCardComponent;


### PR DESCRIPTION
## Summary
 Show a reusable list card component yo show data about news, activities, etc. 

## Jira link
 https://alkemy-labs.atlassian.net/browse/OT105-60?atlOrigin=eyJpIjoiZWMzMGY2OWYxZjllNDc3MTlkYmI0NmViYmVkOTA1OTQiLCJwIjoiaiJ9

## Changes added
-Add material UI components
-Implements image placeholder when doesn't recives a image

## Screenshots

![image](https://user-images.githubusercontent.com/65989119/144975363-818b7c71-4140-4f40-a4ac-a604c18e4e35.png)
