### PR TITLE
Custom Loader Spinner / OT105-92

### DIFF
--- a/Documentation/Loader/Loader.md
+++ b/Documentation/Loader/Loader.md
@@ -1,0 +1,32 @@
+# Loader
+
+Component to show a loader spinner while something loads made with react-loader-spinner.<br/>
+All you need to do is pass, as prop the word: 'full' if you want to show a fullscreen loader or let props empty and show a tiny spinner. <br/>
+
+#### The functions are:
+
+- `successAlert()`
+- `errorAlert()`
+- `infoAlert()`
+- `questionAlert()`
+
+#### Examples:
+
+```jsx
+import React from 'react';
+import LoadSpinner from '../../LoaderSpiner';
+
+const HomePage = () => {
+  return (
+    <div
+      style={{
+        width: '100%',
+        heigth: '100vh',
+      }}>
+      <LoaderSpinner full />
+    </div>
+  );
+};
+
+export default HomePage;
+```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 ## Custom Components/Services:
 
 ### [Alerts](Documentation/Alerts/README.md)
+### [Loader](Documentation/Loader/Loader.md)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-dropzone": "^11.4.2",
+		"react-loader-spinner": "^4.0.0",
 		"react-redux": "^7.2.6",
 		"react-router-dom": "5.3.0",
 		"react-scripts": "4.0.3",

--- a/src/Components/CommonComponents/LoaderSpinner.js
+++ b/src/Components/CommonComponents/LoaderSpinner.js
@@ -3,41 +3,35 @@ import { Box } from '@mui/material';
 import Loader from 'react-loader-spinner';
 import 'react-loader-spinner/dist/loader/css/react-spinner-loader.css';
 
-// if recives props.full shows a fullscreen loader component
 const LoaderSpinner = ({ full = false }) => {
-  if (full) {
-    return (
-      <Box
-        sx={{
-          height: '100vh',
-          width: '100%',
-          position: 'absolute',
-          backgroundColor: 'rgba(255,255,255,0.99)',
-          zIndex: '3',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}>
-        <Loader color="#9AC9FB" height={100} type="ThreeDots" width={100} />
-      </Box>
-    );
-  } else {
-    return (
-      <Box
-        sx={{
-          height: '100%',
-          width: '100%',
-          position: 'relative',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}>
-        <Loader color="#9AC9FB" height={100} type="ThreeDots" width={100} />
-      </Box>
-    );
-  }
+  const flexStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+  const styleFullBox = {
+    height: '100vh',
+    width: '100%',
+    position: 'absolute',
+    backgroundColor: 'rgba(255,255,255,0.99)',
+    zIndex: '3',
+  };
+
+  const styleBox = {
+    height: '100%',
+    width: '100%',
+    position: 'relative',
+  };
+
+  return (
+    <Box
+      sx={
+        full ? { ...flexStyle, ...styleFullBox } : { ...flexStyle, ...styleBox }
+      }>
+      <Loader color="#9AC9FB" height={100} type="ThreeDots" width={100} />
+    </Box>
+  );
 };
 
 export default LoaderSpinner;

--- a/src/Components/CommonComponents/LoaderSpinner.js
+++ b/src/Components/CommonComponents/LoaderSpinner.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import Loader from 'react-loader-spinner';
+import 'react-loader-spinner/dist/loader/css/react-spinner-loader.css';
+
+// if recives props.full shows a fullscreen loader component
+const LoaderSpinner = ({ full = false }) => {
+  if (full) {
+    return (
+      <Box
+        sx={{
+          height: '100vh',
+          width: '100%',
+          position: 'absolute',
+          backgroundColor: 'rgba(255,255,255,0.99)',
+          zIndex: '3',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        <Loader color="#9AC9FB" height={100} type="ThreeDots" width={100} />
+      </Box>
+    );
+  } else {
+    return (
+      <Box
+        sx={{
+          height: '100%',
+          width: '100%',
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        <Loader color="#9AC9FB" height={100} type="ThreeDots" width={100} />
+      </Box>
+    );
+  }
+};
+
+export default LoaderSpinner;


### PR DESCRIPTION
## Summary
 Show a reusable spinner component to show if a component or page is loading. 

## Jira link
https://alkemy-labs.atlassian.net/browse/OT105-92?atlOrigin=eyJpIjoiNWQ5YWNiODQ5MGMyNDRhMTg0ZGUyZDg2MGIxM2NjYTYiLCJwIjoiaiJ9

## Changes added
-Add react-loader-spinner as dependency
-The component recives "full" as prop to show a fullscreen loader
-By default returns a tiny loader to use inside other components

## Screenshots
Default: 
![image](https://user-images.githubusercontent.com/65989119/145431261-05ce3652-1789-497f-add7-e2a9397a48eb.png)

With "full" Prop: 
![image](https://user-images.githubusercontent.com/65989119/145431471-56219842-3cdb-49c2-9742-369f6ece2426.png)



