### PR TITLE
OT105-69 / Bugfix for Auth header

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,8 +1,16 @@
 import axios from 'axios';
 
+const getAuthorizationHeader = () => {
+  const token = localStorage.getItem('token');
+  const auth = 'Bearer ' + token;
+
+  return token !== null ? auth : null;
+};
+
 const config = {
   headers: {
-    Group: 1, //Aqui va el ID del equipo!!
+    Group: 105,
+    Authorization: getAuthorizationHeader(),
   },
 };
 
@@ -11,17 +19,6 @@ const Get = () => {
     .get('https://jsonplaceholder.typicode.com/users', config)
     .then((res) => console.log(res))
     .catch((err) => console.log(err));
-};
-
-const getAuthorizationHeader = () => {
-  if (!window.localStorage.hasOwnProperty('token')) return new Error('no token found');
-  const token = localStorage.token;
-
-  const Header = {
-    Authorization: 'Bearer' + token,
-  };
-
-  return Header;
 };
 
 export default Get;


### PR DESCRIPTION
## Summary
Fix how the function get the info from localstorage and add the response to the Config object in a property Authorization.

## Jira link
[OT105-69](https://alkemy-labs.atlassian.net/browse/OT105-69)

## Changes added
- fix getAuthorizationHeader function.
- add response in Config object

## Screenshots
![Screenshot from 2021-12-09 16-10-25](https://user-images.githubusercontent.com/36646957/145462405-6cf033e1-97eb-4d3e-acc1-15ce56997f84.png)

