### PR TITLE
OT105-73 / Reusable delete method for private api endpoints

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -14,11 +14,12 @@ const config = {
   },
 };
 
-const Get = () => {
-  axios
-    .get('https://jsonplaceholder.typicode.com/users', config)
-    .then((res) => console.log(res))
-    .catch((err) => console.log(err));
-};
+export const privateDelete = async (path, id) => {
+  try {
+    const response = await axios.delete(`${path}/${id}`, config);
 
-export default Get;
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
## Summary
Reusable method that receive an url path and id as a parameter and sends a delete method with the group id and token in the body of the request.

## Jira link
[OT105-73](https://alkemy-labs.atlassian.net/browse/OT105-73)

## Changes added
- add delete method to privateApiService.js
- delete the example function Get and its export

## Screenshots
![Screenshot from 2021-12-10 16-04-48](https://user-images.githubusercontent.com/36646957/145630835-7b911948-9488-405c-ab06-17c35b54d0d0.png)
![Screenshot from 2021-12-10 16-05-34](https://user-images.githubusercontent.com/36646957/145630845-fe1e2868-d088-47c6-8540-e4d08ed17e68.png)

