### PR TITLE
Feat/backoffice header OT105-123

### DIFF
--- a/src/Components/Backoffice/BackofficeDashboard.js
+++ b/src/Components/Backoffice/BackofficeDashboard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Typography } from '@mui/material';
 import CustomAppBar from '../CustomComponents/CustomAppBar/CustomAppBar';
+import HeaderBackoffice from '../CommonComponents/HeaderBackoffice';
 import {
   paragraphText40,
   paragraphText45,
@@ -22,7 +23,7 @@ const BackOfficeDashBoard = () => {
 
   return (
     <>
-      <CustomAppBar user={user} />
+      <HeaderBackoffice />
 
       <Typography sx={paragraphText40} variant="p" gutterBottom component="p">
         {user.name}

--- a/src/Components/CommonComponents/HeaderBackoffice.js
+++ b/src/Components/CommonComponents/HeaderBackoffice.js
@@ -1,0 +1,24 @@
+import { AppBar, Box, IconButton, Toolbar, Typography } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+
+const HeaderBackoffice = () => {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar position="static" sx={{ backgroundColor: '#9AC9FB' }}>
+        <Toolbar sx={{ justifyContent: 'left' }}>
+          <IconButton
+            aria-label="menu"
+            color="inherit"
+            edge="start"
+            size="large"
+            sx={{ mr: 2 }}>
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h5">Backoffice</Typography>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};
+
+export default HeaderBackoffice;


### PR DESCRIPTION
## Summary
 Show a reusable header component with a button to show/hide sidebarComponent in backoffice.

## Jira link
https://alkemy-labs.atlassian.net/browse/OT105-123?atlOrigin=eyJpIjoiZGJlZjFmNWJkNjQ0NGUxMmE2NjEwNjg3MDI0OTdmM2IiLCJwIjoiaiJ9

## Changes added
-Create the header component using material"
- Add a button to show or hide a sidebar component.
-Add header to Backoffice Dashboard.

## Screenshots
![image](https://user-images.githubusercontent.com/65989119/146989541-68539ee6-58b0-4b76-bf86-bacfdb8eb35a.png)


