### PR TITLE
OT105-126 / Create Sidebar component for Backoffice

### DIFF
--- a/src/Components/CommonComponents/HeaderBackoffice.js
+++ b/src/Components/CommonComponents/HeaderBackoffice.js
@@ -1,22 +1,58 @@
-import { AppBar, Box, IconButton, Toolbar, Typography } from '@mui/material';
+import { useState } from 'react';
+import Sidebar from './SidebarBackoffice';
+import {
+  AppBar,
+  Box,
+  CssBaseline,
+  IconButton,
+  Toolbar,
+  Typography,
+} from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 
-const HeaderBackoffice = () => {
+const drawerWidth = 240;
+
+const HeaderBackoffice = ({ children }) => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setDrawerOpen(!drawerOpen);
+  };
+
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static" sx={{ backgroundColor: '#9AC9FB' }}>
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
+      <AppBar
+        position="fixed"
+        sx={{ backgroundColor: '#9AC9FB', zIndex: { xl: '1201' } }}>
         <Toolbar sx={{ justifyContent: 'left' }}>
           <IconButton
             aria-label="menu"
             color="inherit"
             edge="start"
             size="large"
-            sx={{ mr: 2 }}>
+            sx={{ mr: 2, display: { xl: 'none' } }}
+            onClick={handleDrawerToggle}>
             <MenuIcon />
           </IconButton>
           <Typography variant="h5">Backoffice</Typography>
         </Toolbar>
       </AppBar>
+      <Sidebar
+        drawerWidth={drawerWidth}
+        handleDrawerToggle={handleDrawerToggle}
+        isOpen={drawerOpen}
+      />
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: 3,
+          width: { xl: `calc(100% - ${drawerWidth}px)` },
+        }}>
+        <Toolbar />
+        {children}
+      </Box>
     </Box>
   );
 };

--- a/src/Components/CommonComponents/SidebarBackoffice.js
+++ b/src/Components/CommonComponents/SidebarBackoffice.js
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Box,
+  Divider,
+  Drawer,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+} from '@mui/material';
+import InboxIcon from '@mui/icons-material/MoveToInbox'; //BUscar iconss
+
+const routes = [
+  {
+    name: 'Actividades',
+    path: '/backoffice/activities',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Categorías',
+    path: '/backoffice/categories',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Miembros',
+    path: '/backoffice/members',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Novedades',
+    path: '/backoffice/news',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Organización',
+    path: '/backoffice/organization',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Slides',
+    path: '/backoffice/slides',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Testimonios',
+    path: '/backoffice/testimonies',
+    icon: () => <InboxIcon />,
+  },
+  {
+    name: 'Usuarios',
+    path: '/backoffice/users',
+    icon: () => <InboxIcon />,
+  },
+];
+
+const Sidebar = ({ isOpen, handleDrawerToggle, drawerWidth }) => {
+  const LinkList = () => {
+    return (
+      <List>
+        {routes.map((route) => (
+          <ListItem key={route.name} button component={Link} to={route.path}>
+            <ListItemIcon>{route.icon()}</ListItemIcon>
+            <ListItemText primary={route.name} />
+          </ListItem>
+        ))}
+      </List>
+    );
+  };
+
+  const permanentDrawer = (
+    <Drawer
+      open
+      sx={{
+        display: { xs: 'none', xl: 'block' },
+        '& .MuiDrawer-paper': {
+          boxSizing: 'border-box',
+          width: drawerWidth,
+        },
+      }}
+      variant="permanent">
+      <Toolbar />
+      <Box sx={{ overflow: 'auto' }}>
+        <LinkList />
+      </Box>
+    </Drawer>
+  );
+
+  const temporaryDrawer = (
+    <Drawer
+      ModalProps={{
+        keepMounted: true,
+      }}
+      open={isOpen}
+      sx={{
+        display: { xs: 'block', xl: 'none' },
+        '& .MuiDrawer-paper': {
+          boxSizing: 'border-box',
+          width: drawerWidth,
+        },
+      }}
+      variant="temporary"
+      onClose={handleDrawerToggle}>
+      <Box sx={{ overflow: 'auto' }}>
+        <Toolbar />
+        <Divider />
+        <LinkList />
+      </Box>
+    </Drawer>
+  );
+
+  return (
+    <Box
+      aria-label="backoffice routes"
+      component="nav"
+      sx={{ width: { xl: drawerWidth }, flexShrink: { xl: 0 } }}>
+      {permanentDrawer}
+      {temporaryDrawer}
+    </Box>
+  );
+};
+
+export default Sidebar;

--- a/src/Components/CommonComponents/SidebarBackoffice.js
+++ b/src/Components/CommonComponents/SidebarBackoffice.js
@@ -10,48 +10,55 @@ import {
   ListItemText,
   Toolbar,
 } from '@mui/material';
-import InboxIcon from '@mui/icons-material/MoveToInbox'; //BUscar iconss
+import CampaignIcon from '@mui/icons-material/Campaign';
+import CategoryIcon from '@mui/icons-material/Category';
+import BadgeIcon from '@mui/icons-material/Badge';
+import NewspaperIcon from '@mui/icons-material/Newspaper';
+import BusinessIcon from '@mui/icons-material/Business';
+import BurstModeIcon from '@mui/icons-material/BurstMode';
+import ModeCommentIcon from '@mui/icons-material/ModeComment';
+import GroupIcon from '@mui/icons-material/Group';
 
 const routes = [
   {
     name: 'Actividades',
     path: '/backoffice/activities',
-    icon: () => <InboxIcon />,
+    icon: () => <CampaignIcon />,
   },
   {
     name: 'Categorías',
     path: '/backoffice/categories',
-    icon: () => <InboxIcon />,
+    icon: () => <CategoryIcon />,
   },
   {
     name: 'Miembros',
     path: '/backoffice/members',
-    icon: () => <InboxIcon />,
+    icon: () => <BadgeIcon />,
   },
   {
     name: 'Novedades',
     path: '/backoffice/news',
-    icon: () => <InboxIcon />,
+    icon: () => <NewspaperIcon />,
   },
   {
     name: 'Organización',
     path: '/backoffice/organization',
-    icon: () => <InboxIcon />,
+    icon: () => <BusinessIcon />,
   },
   {
     name: 'Slides',
     path: '/backoffice/slides',
-    icon: () => <InboxIcon />,
+    icon: () => <BurstModeIcon />,
   },
   {
     name: 'Testimonios',
     path: '/backoffice/testimonies',
-    icon: () => <InboxIcon />,
+    icon: () => <ModeCommentIcon />,
   },
   {
     name: 'Usuarios',
     path: '/backoffice/users',
-    icon: () => <InboxIcon />,
+    icon: () => <GroupIcon />,
   },
 ];
 


### PR DESCRIPTION
## Summary
Added sidebar to navigate the backoffice routes. In resolutions <1536px appears when click on the header button and for the rest it always shows.

## Jira link
[OT105-126](https://alkemy-labs.atlassian.net/browse/OT105-126)

## Changes added
- Add SidebarBackoffice
- Modify HeaderBackoffice to be able to use the Sidebar

## Screenshots
![localhost_3000_backoffice](https://user-images.githubusercontent.com/36646957/147259061-70f5e37c-8883-46af-99a7-2a749620231a.png)
![localhost_3000_backoffice (1)](https://user-images.githubusercontent.com/36646957/147259294-9dd21592-be72-4713-a2ac-0a69b0a72c8b.png)

